### PR TITLE
Added links to Outlook, Project and OneNote sideloading

### DIFF
--- a/src/office-toolbox.ts
+++ b/src/office-toolbox.ts
@@ -231,9 +231,10 @@ async function sideload(application: string, manifestPath: string) {
       application = await promptForApplication();
     }
 
-    if(application === 'word' || application === 'excel' || application === 'powerpoint'){
+    if(util.applicationProperties[application].canSideload){
       manifestPath = await checkAndPromptForPath(application, manifestPath);
       await util.sideload(application, manifestPath);
+      console.log('For more information about how to sideload Office Add-ins, visit the following link: ' + util.applicationProperties[application].documentationLink);
     }
     else{
       console.log('Automatic sideloading is not available for this app, please follow the instructions in the following link: ' + util.applicationProperties[application].documentationLink);

--- a/src/office-toolbox.ts
+++ b/src/office-toolbox.ts
@@ -68,7 +68,7 @@ async function promptForApplication(): Promise<string> {
     name: 'application',
     type: 'list',
     message: 'Which application are you targeting?',
-    choices: ['Word', 'Excel', 'PowerPoint']
+    choices: ['Word', 'Excel', 'PowerPoint', 'Outlook', 'OneNote', 'Project']
   };
   return inquirer.prompt(question).then((answer) => {
     return Promise.resolve(answer['application'].toLowerCase());
@@ -231,8 +231,14 @@ async function sideload(application: string, manifestPath: string) {
       application = await promptForApplication();
     }
 
-    manifestPath = await checkAndPromptForPath(application, manifestPath);
-    await util.sideload(application, manifestPath);
+    if(application === 'word' || application === 'excel' || application === 'powerpoint'){
+      manifestPath = await checkAndPromptForPath(application, manifestPath);
+      await util.sideload(application, manifestPath);
+    }
+    else{
+      console.log('Automatic sideloading is not available for this app, please follow the instructions in the following link: ' + util.applicationProperties[application].documentationLink);
+    }
+    
   } catch (err) {
     logRejection(err);
   }

--- a/src/office-toolbox.ts
+++ b/src/office-toolbox.ts
@@ -231,13 +231,15 @@ async function sideload(application: string, manifestPath: string) {
       application = await promptForApplication();
     }
 
-    if(util.applicationProperties[application].canSideload){
+    const appProperties = util.applicationProperties[application];
+
+    if (appProperties.canSideload) {
       manifestPath = await checkAndPromptForPath(application, manifestPath);
       await util.sideload(application, manifestPath);
-      console.log('For more information about how to sideload Office Add-ins, visit the following link: ' + util.applicationProperties[application].documentationLink);
+      console.log(`For more information about how to sideload Office Add-ins, visit the following link: ${appProperties.documentationLink}`);
     }
-    else{
-      console.log('Automatic sideloading is not available for this app, please follow the instructions in the following link: ' + util.applicationProperties[application].documentationLink);
+    else {
+      console.log(`Automatic sideloading is not available for this app, please follow the instructions in the following link: ${appProperties.documentationLink}`);
     }
     
   } catch (err) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,8 +28,8 @@ export const applicationProperties = {
       templateName: 'DocumentWithTaskPane.docx'
     },
     sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Word/Data/Documents/wef'),
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
-    canSideload:true
+    documentationLink: "https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
+    canSideload: true
   },
   excel: {
     TaskPaneApp: {
@@ -41,8 +41,8 @@ export const applicationProperties = {
       templateName: 'BookWithContent.xlsx'
     },
     sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Excel/Data/Documents/wef'),
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
-    canSideload:true
+    documentationLink: "https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
+    canSideload: true
   },
   powerpoint: {
     TaskPaneApp: {
@@ -54,20 +54,20 @@ export const applicationProperties = {
       templateName: 'PresentationWithContent.pptx'
     },
     sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef'),
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
-    canSideload:true
+    documentationLink: "https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
+    canSideload: true
   },
-  outlook:{
-    documentationLink:"https://docs.microsoft.com/en-us/outlook/add-ins/sideload-outlook-add-ins-for-testing",
-    canSideload:false
+  outlook: {
+    documentationLink: "https://docs.microsoft.com/en-us/outlook/add-ins/sideload-outlook-add-ins-for-testing",
+    canSideload: false
   },
-  onenote:{
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/onenote/onenote-add-ins-getting-started",
-    canSideload:false
+  onenote: {
+    documentationLink: "https://docs.microsoft.com/en-us/office/dev/add-ins/onenote/onenote-add-ins-getting-started",
+    canSideload: false
   },
-  project:{
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/project/project-add-ins",
-    canSideload:false
+  project: {
+    documentationLink: "https://docs.microsoft.com/en-us/office/dev/add-ins/project/project-add-ins",
+    canSideload: false
   }
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,9 @@ export const applicationProperties = {
       webExtensionPath: 'word/webextensions/webextension.xml',
       templateName: 'DocumentWithTaskPane.docx'
     },
-    sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Word/Data/Documents/wef')
+    sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Word/Data/Documents/wef'),
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
+    canSideload:true
   },
   excel: {
     TaskPaneApp: {
@@ -38,7 +40,9 @@ export const applicationProperties = {
       webExtensionPath: 'xl/webextensions/webextension.xml',
       templateName: 'BookWithContent.xlsx'
     },
-    sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Excel/Data/Documents/wef')
+    sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Excel/Data/Documents/wef'),
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
+    canSideload:true
   },
   powerpoint: {
     TaskPaneApp: {
@@ -49,16 +53,21 @@ export const applicationProperties = {
       webExtensionPath: 'ppt/slides/udata/data.xml',
       templateName: 'PresentationWithContent.pptx'
     },
-    sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef')
+    sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef'),
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins",
+    canSideload:true
   },
   outlook:{
-    documentationLink:"https://docs.microsoft.com/en-us/outlook/add-ins/sideload-outlook-add-ins-for-testing"
+    documentationLink:"https://docs.microsoft.com/en-us/outlook/add-ins/sideload-outlook-add-ins-for-testing",
+    canSideload:false
   },
   onenote:{
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/onenote/onenote-add-ins-getting-started"
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/onenote/onenote-add-ins-getting-started",
+    canSideload:false
   },
   project:{
-    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/project/project-add-ins"
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/project/project-add-ins",
+    canSideload:false
   }
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,6 +50,15 @@ export const applicationProperties = {
       templateName: 'PresentationWithContent.pptx'
     },
     sideloadingDirectory: path.join(os.homedir(), 'Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef')
+  },
+  outlook:{
+    documentationLink:"https://docs.microsoft.com/en-us/outlook/add-ins/sideload-outlook-add-ins-for-testing"
+  },
+  onenote:{
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/onenote/onenote-add-ins-getting-started"
+  },
+  project:{
+    documentationLink:"https://docs.microsoft.com/en-us/office/dev/add-ins/project/project-add-ins"
   }
 };
 


### PR DESCRIPTION
The YoOffice template generator now creates a script for sideloading in all projects and hosts (including OneNote, Outlook and Project), so the goal of this change is that when the user tries to sideload an Add-in in an unsupported platform (OneNote, Outlook and Project) instead of getting an error we will display a link to sideloading the Add-in, in the future we can change that to actually sideload it in the corresponding host.