### PR TITLE
Sideload: create file in temp dir

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -448,6 +448,44 @@ function getInfoForManifests(manifestPaths: string[]): Promise<any> {
   });
 }
 
+/** 
+ * makePathUnique 
+ * @description Given a file path, returns a unique file path where the file doesn't exist by 
+ * appending a period and a numeric suffix, starting from 2. 
+ * @param tryToDelete If true, first try to delete the file if it exists.
+ */
+function makePathUnique(originalPath: string, tryToDelete: boolean = false): string {
+  let currentPath = originalPath;
+  let parsedPath = null;
+  let suffix = 1;
+  
+  while (fs.existsSync(currentPath)) {
+    let deleted: boolean = false;
+
+    if (tryToDelete) {
+      try {
+        fs.removeSync(currentPath);
+        deleted = true;
+        console.log(`Deleted file: ${currentPath}`);  
+      } catch (err) {
+        console.log(`File is in use: ${currentPath}`);  
+      }
+    }
+
+    if (!deleted) {      
+      ++suffix;
+      
+      if (parsedPath == null) {
+        parsedPath = path.parse(originalPath);      
+      }
+      
+      currentPath = path.join(parsedPath.dir, `${parsedPath.name}.${suffix}${parsedPath.ext}`);
+    }
+  }
+
+  return currentPath;
+}
+
 function generateTemplateFile(application: string, type: string, id: string, version: string): Promise<any> {
   return new Promise(async (resolve, reject) => {
     try {
@@ -459,12 +497,8 @@ function generateTemplateFile(application: string, type: string, id: string, ver
       const defaultTemplateName = applicationProperties[application][type].templateName;
       const webExtensionPath = applicationProperties[application][type].webExtensionPath;
       const extension = path.extname(defaultTemplateName);
-      const templatePath = path.join(os.tmpdir(), `${application} add-in ${id}${extension}`);
+      const templatePath = makePathUnique(path.join(os.tmpdir(), `${application} add-in ${id}${extension}`), true);
   
-      if (fs.existsSync(templatePath)) { 
-        fs.removeSync(templatePath);
-      }
-
       fs.ensureDirSync(path.dirname(templatePath));
 
       console.log(`Generating file ${templatePath}`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -458,14 +458,14 @@ function generateTemplateFile(application: string, type: string, id: string, ver
 
       const defaultTemplateName = applicationProperties[application][type].templateName;
       const webExtensionPath = applicationProperties[application][type].webExtensionPath;
-      let templatePath = path.join(process.cwd(), defaultTemplateName);
-
-      let i = 0;
-      while (fs.existsSync(templatePath)) {
-        const [templateName, templateExtension] = defaultTemplateName.split('.');
-        templatePath = path.join(process.cwd(), templateName + i + '.' + templateExtension);
-        i++;
+      const extension = path.extname(defaultTemplateName);
+      const templatePath = path.join(os.tmpdir(), `${application} add-in ${id}${extension}`);
+  
+      if (fs.existsSync(templatePath)) { 
+        fs.removeSync(templatePath);
       }
+
+      fs.ensureDirSync(path.dirname(templatePath));
 
       console.log(`Generating file ${templatePath}`);
 


### PR DESCRIPTION
Fixes issue https://github.com/OfficeDev/office-toolbox/issues/7

To allow the command to be repeatable and not clutter the source directory with new files, the sideload command is changed to create the document in the temp directory with filename "{app} add-in {id}" where app is the application host such as "excel" and {id} is the add-in guid from the manifest.

The same file path is used each time sideload is run. 

I was going to only create it if it didn't exist, but if the version is changed, the new version needs to be in the document. Therefore, the file is generated each time, deleting any existing file first.