### PR TITLE
Update the usage of appInsightsClient.trackException

### DIFF
--- a/src/office-toolbox.ts
+++ b/src/office-toolbox.ts
@@ -12,27 +12,25 @@ import * as inquirer from 'inquirer';
 import * as path from 'path';
 
 import * as util from './util';
-import { Telemetry, ExceptionTelemetry } from 'applicationinsights/out/Declarations/Contracts';
 
 function logRejection(err) {
-  // When the error might contain personally identifiable information, only track the generic part.
-  let exceptionTelemetry : ExceptionTelemetry;
-  if (err instanceof Array && err.length) {
-    exceptionTelemetry['exception'] = new Error(err[0]);
-    for (let message of err) {
-      console.log(chalk.default.red(message));
-    }
-  }
-  else if (typeof err === "string"){
-    exceptionTelemetry['exception'] = new Error(err);
-    console.log(chalk.default.red(err));
-  }
-  else if (err instanceof Error){
-    exceptionTelemetry['exception'] = err;
-    console.log(chalk.default.red(err.message));
-  }
+  let error: Error = undefined;
 
-  util.appInsightsClient.trackException(exceptionTelemetry);
+  if (err instanceof Array) {
+     if (err.length) {
+         error = (err[0] instanceof Error) ? err[0] : new Error(err[0]);
+  
+         for (const message of err) {
+             console.log(chalk.default.red(message));
+          }
+      }
+  }
+  else {
+      error = (err instanceof Error) ? err : new Error(err);
+      console.log(chalk.default.red(err));  
+  }
+  
+  util.appInsightsClient.trackException({ exception: error });
 }
 
 // PROMPT FUNCTIONS //

--- a/src/office-toolbox.ts
+++ b/src/office-toolbox.ts
@@ -16,13 +16,13 @@ import * as util from './util';
 function logRejection(err) {
   // When the error might contain personally identifiable information, only track the generic part.
   if (err instanceof Array && err.length) {
-    util.appInsightsClient.trackException(err[0]);
+    util.appInsightsClient.trackException({exception: new Error(err[0])});
     for (let message of err) {
       console.log(chalk.default.red(message));
     }
   }
   else {
-    util.appInsightsClient.trackException(err[0]);
+    util.appInsightsClient.trackException({exception: new Error(err)});
     console.log(chalk.default.red(err));
   }
 }

--- a/src/office-toolbox.ts
+++ b/src/office-toolbox.ts
@@ -12,19 +12,27 @@ import * as inquirer from 'inquirer';
 import * as path from 'path';
 
 import * as util from './util';
+import { Telemetry, ExceptionTelemetry } from 'applicationinsights/out/Declarations/Contracts';
 
 function logRejection(err) {
   // When the error might contain personally identifiable information, only track the generic part.
+  let exceptionTelemetry : ExceptionTelemetry;
   if (err instanceof Array && err.length) {
-    util.appInsightsClient.trackException({exception: new Error(err[0])});
+    exceptionTelemetry['exception'] = new Error(err[0]);
     for (let message of err) {
       console.log(chalk.default.red(message));
     }
   }
-  else {
-    util.appInsightsClient.trackException({exception: new Error(err)});
+  else if (typeof err === "string"){
+    exceptionTelemetry['exception'] = new Error(err);
     console.log(chalk.default.red(err));
   }
+  else if (err instanceof Error){
+    exceptionTelemetry['exception'] = err;
+    console.log(chalk.default.red(err.message));
+  }
+
+  util.appInsightsClient.trackException(exceptionTelemetry);
 }
 
 // PROMPT FUNCTIONS //


### PR DESCRIPTION
The new trackException API is working in this way: client.trackException({exception: new Error("handled exceptions can be logged with this method")});. It no longer takes a string, otherwise exceptions will be thrown inside the applicationinsights. Update our usage to follow the latest API design.