### PR TITLE
Update addManifestToSideloadingDirectory rejection

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -141,7 +141,7 @@ function addManifestToSideloadingDirectory(application: string, manifestPath: st
       const stat = fs.statSync(manifestPath);
       const sideloadingStat = fs.statSync(sideloadingManifestPath);
 
-      if (stat.ino !== sideloadingStat.ino && stat.dev !== sideloadingStat.dev) {
+      if (stat.ino !== sideloadingStat.ino || stat.dev !== sideloadingStat.dev) {
         return reject(['Remove the manifest with matching name before adding this one. ', fs.realpathSync(sideloadingManifestPath)]);
       }
     }


### PR DESCRIPTION
addManifestToSideloadingDirectory will reject change if manifest file already exists. Previously it checked that dev&inode were BOTH different. Now it checks that at least one of dev&inode are different.

Fixes #25