### PR TITLE
Generate unique manifest file name when sideloading on Mac

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach",
+            "port": 9229
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}\\app\\util.js",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/app/**/*.js"
+            ]
+        }
+    ]
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -172,6 +172,7 @@ function removeManifestFromSideloadingDirectory(inputApplication: string, manife
       for (let application of Object.keys(applicationProperties)) {
         if (!inputApplication || application === inputApplication) {
           const sideloadingDirectory = applicationProperties[application].sideloadingDirectory;
+          const [type, manifestGuid, version] = await parseManifest(manifestPathToRemove);
 
           if (!fs.existsSync(sideloadingDirectory)) {
             continue;

--- a/src/util.ts
+++ b/src/util.ts
@@ -139,7 +139,7 @@ async function addManifestToSideloadingDirectory(application: string, manifestPa
     return fs.ensureLinkSync(manifestPath, sideloadingManifestPath);
 
   } catch (err) {
-    throw new Error(`addManifestToSideloadingDirectory failed with error:\n${err}`);
+    throw new Error(`Unable to add manifest to the sideloading directory\n${err}`);
   }
 }
 
@@ -191,7 +191,7 @@ async function removeManifestFromSideloadingDirectory(inputApplication: string, 
     }
     return console.log('No manifests were found to remove. Use "list" to show manifests that have been added.');
   } catch (err) {
-    throw new Error(`removeManifestFromSideloadingDirectory failed with error:\n${err}`);
+    throw new Error(`Unable to remove the manifest from the sideloading directory.\n${err}`);
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -139,7 +139,7 @@ async function addManifestToSideloadingDirectory(application: string, manifestPa
     return fs.ensureLinkSync(manifestPath, sideloadingManifestPath);
 
   } catch (err) {
-    throw new Error(`Unable to add manifest to the sideloading directory\n${err}`);
+    throw new Error(`Unable to add manifest to the sideloading directory.\n${err}`);
   }
 }
 


### PR DESCRIPTION
- Changes ensure we always generate a unique manifest file name to cache in the WEF folder on Mac during sideloading
- Remove check for duplicate manifest in WEF. If we encounter a duplicate manifest, just overwrite it
- Update manifest remove code to construct the manifest file path for removal using the manifest guid