### PR TITLE
Change structure of Developer registry

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -400,7 +400,7 @@ function getIdsAndManifests(application: string): Promise<Array<[string, string]
   });
 }
 
-function parseManifest(manifestPath: string): Promise<[string, string, string]> {
+export function parseManifest(manifestPath: string): Promise<[string, string, string]> {
   return new Promise(async (resolve, reject) => {
     try {
       const parser = new xml2js.Parser();

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,9 +100,9 @@ export function getManifests(application: string): Promise<string[]> {
     : getManifestsFromSideloadingDirectory(application);
 }
 
-export function addManifest(application: string, manifestPath: string): Promise<any> {
+export function addManifest(application: string, parsedGuid: string, manifestPath: string): Promise<any> {
   return (process.platform === 'win32')
-    ? addManifestToRegistry(manifestPath)
+    ? addManifestToRegistry(parsedGuid, manifestPath)
     : addManifestToSideloadingDirectory(application, manifestPath);
 }
 
@@ -250,8 +250,8 @@ function querySideloadingRegistry(commands: string[]): Promise<string> {
   });
 }
 
-function addManifestToRegistry(manifestPath: string): Promise<any> {
-  return querySideloadingRegistry(['Set-ItemProperty -LiteralPath $RegistryPath -Name "' + manifestPath + '" -Value "' + manifestPath + '"']);
+function addManifestToRegistry(parsedGuid: string, manifestPath: string): Promise<any> {
+  return querySideloadingRegistry(['Set-ItemProperty -LiteralPath $RegistryPath -Name "' + parsedGuid + '" -Value "' + manifestPath + '"']);
 }
 
 export function getManifestsFromRegistry(): Promise<string[]> {
@@ -307,7 +307,7 @@ function sideloadManifest(application: string, manifestPath: string): Promise<an
       }
 
       const [parsedType, parsedGuid, parsedVersion] = await parseManifest(manifestPath);
-      await addManifest(application, manifestPath);
+      await addManifest(application, parsedGuid, manifestPath);
       const templateFile = await generateTemplateFile(application, parsedType, parsedGuid, parsedVersion);
 
       appInsightsClient.trackEvent({ name: 'open', properties: { guid: parsedGuid, version: parsedVersion } });

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,9 +100,9 @@ export function getManifests(application: string): Promise<string[]> {
     : getManifestsFromSideloadingDirectory(application);
 }
 
-export function addManifest(application: string, parsedGuid: string, manifestPath: string): Promise<any> {
+export function addManifest(application: string, manifestId: string, manifestPath: string): Promise<any> {
   return (process.platform === 'win32')
-    ? addManifestToRegistry(parsedGuid, manifestPath)
+    ? addManifestToRegistry(manifestId, manifestPath)
     : addManifestToSideloadingDirectory(application, manifestPath);
 }
 
@@ -250,8 +250,8 @@ function querySideloadingRegistry(commands: string[]): Promise<string> {
   });
 }
 
-function addManifestToRegistry(parsedGuid: string, manifestPath: string): Promise<any> {
-  return querySideloadingRegistry(['Set-ItemProperty -LiteralPath $RegistryPath -Name "' + parsedGuid + '" -Value "' + manifestPath + '"']);
+function addManifestToRegistry(manifestId: string, manifestPath: string): Promise<any> {
+  return querySideloadingRegistry(['Set-ItemProperty -LiteralPath $RegistryPath -Name "' + manifestId + '" -Value "' + manifestPath + '"']);
 }
 
 export function getManifestsFromRegistry(): Promise<string[]> {

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,7 +15,8 @@ describe("Add manifest", function () {
         let testManifestPath = path.resolve(`${process.cwd()}/test/test-manifest.xml`);
 
         it(process.platform === "win32" ? "Manifest should have been added to the registry" : "Manifest should have been added to the WEF folder and given a unique name", async function () {
-            await officeToolbox.addManifest(application, testManifestPath);
+            const [parsedType, parsedGuid, parsedVersion] = await officeToolbox.parseManifest(testManifestPath);
+            await officeToolbox.addManifest(application, parsedGuid, testManifestPath);
 
             if (process.platform === "win32") {
                 manifests = await officeToolbox.getManifests(application);


### PR DESCRIPTION
In the past, the structure of Developer registry (Computer\HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\WEF\Developer) is like the following:
Value Name: Path to manifest
Value Data: Path to manifest
Such structure is duplicated and value name is never used. After this change, the structure would be:
Value Name: GUID
Value Data: Path to manifest