### PR TITLE
Update docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ extensions:
 
 # office-toolbox
 
-Office-Toolbox is a set of tools for validating, and sideloading an Office Add-in. It is not (yet) a part of the official Office Add-in toolchain, but allows you to bypass the manual steps for sideloading add-ins. If you prefer to use the official Office toolchain, see our documentation on [getting started with Office Add-ins](https://dev.office.com/docs/add-ins/get-started/create-an-office-add-in-using-any-editor) and [how to sideload an add-in](https://dev.office.com/docs/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins).
+Office-Toolbox is a set of tools for validating, and sideloading an Office Add-in. It is not (yet) a part of the official Office Add-in toolchain, but allows you to bypass the manual steps for sideloading add-ins. If you prefer to use the official Office toolchain, see our documentation on [getting started with Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/) and [how to sideload an add-in](https://docs.microsoft.com/office/dev/add-ins/testing/test-debug-office-add-ins#sideload-an-office-add-in-for-testing).
 
 ## Installation
 > **Important:** If this is the first time you're using this tool, first install [Node.js](https://nodejs.org). For developers on Mac, we recommend using [Node Version Manager](https://github.com/creationix/nvm) to install Node.js with the right permissions. When the installation completes, restart your console (or if you are using Windows, restart your machine) to ensure you use the updated system environment variables.


### PR DESCRIPTION
The `dev.office.com` site was deprecated a while back; Office Add-ins docs now reside on the `docs.microsoft.com` site. This PR updates URLs accordingly.